### PR TITLE
when host views lists it will display only their host card, and not a…

### DIFF
--- a/src/Components/HostListView/index.js
+++ b/src/Components/HostListView/index.js
@@ -25,9 +25,20 @@ class HostListView extends Component {
 }
 
 const mapStateToProps = state => {
+  const loggedInUser = state.auth.user
+  let shelter = {}
+  let hosts = []
+  if (loggedInUser.type === "shelter"){
+    shelter = loggedInUser.data
+    hosts = state.hosts
+  }
+  if (loggedInUser.type === "host"){
+    shelter = loggedInUser.data.shelterId;
+    hosts = [loggedInUser]
+  }
   return {
-    hosts: state.hosts,
-    shelter: state.auth.user.data
+    hosts: hosts,
+    shelter: shelter
   };
 };
 


### PR DESCRIPTION
when logged in as a host:
1. shelter picture and name is shown
2. only their own host card is shown